### PR TITLE
utf8変換機能を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ exec = "./main"
 	* 省略時カレントディレクトリになります
 * exec
 	* 実行するコマンドです
+* stdout_capture
+	* `"never"`, `"onerror"`(デフォルト), `"always"` が指定可能です
+	* alwaysではコマンド終了時、onerrorではエラーで終了時にコマンドの標準出力とエラー出力の内容をlauncherのボタンの下に表示します
+* stdout_utf8 (windowsのみ)
+	* falseの場合(デフォルト)、stdout_captureで取得したデータはANSIエンコーディングとみなし、UTF-8に変換してからWebCFaceに送られます。
+	* trueの場合、stdout_captureで取得したデータをUTF-8とみなし、そのままWebCFaceに送ります。
 
 # webcface-cv-capture
 

--- a/common/common.h
+++ b/common/common.h
@@ -1,1 +1,25 @@
 #define TOOLS_VERSION_DISP(name) name " (webcface-tools " TOOLS_VERSION ")"
+
+#ifdef WIN32
+#include <windows.h>
+#include <string>
+
+inline std::string acpToUTF8(const char *bytes, int n) {
+    auto length = MultiByteToWideChar(CP_ACP, 0, bytes, n, nullptr, 0);
+    std::wstring result(length, '\0');
+    MultiByteToWideChar(CP_ACP, 0, bytes, n, result.data(),
+                        static_cast<int>(result.length()));
+    auto length_utf8 = WideCharToMultiByte(CP_UTF8, 0, result.data(),
+                                           static_cast<int>(result.length()),
+                                           nullptr, 0, nullptr, nullptr);
+    std::string result_utf8(length_utf8, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, result.data(),
+                        static_cast<int>(result.length()), result_utf8.data(),
+                        static_cast<int>(result_utf8.length()), nullptr,
+                        nullptr);
+    return result_utf8;
+}
+inline std::string acpToUTF8(const std::string &str) {
+    return acpToUTF8(str.c_str(), static_cast<int>(str.size()));
+}
+#endif

--- a/launcher/command.h
+++ b/launcher/command.h
@@ -2,30 +2,62 @@
 #include <webcface/webcface.h>
 #include <string>
 #include <memory>
+#include "../common/common.h"
 
+enum class CaptureMode {
+    never,
+    onerror,
+    always,
+};
 struct Command {
     Command(const Command &) = delete;
     Command &operator=(const Command &) = delete;
     Command(WebCFace::Client &wcli, const std::string &name,
-            const std::string &exec, const std::string &workdir)
-        : name(name), exec(exec), workdir(workdir) {
+            const std::string &exec, const std::string &workdir,
+            const std::string &capture_stdout, bool stdout_is_utf8)
+        : name(name), exec(exec), workdir(workdir),
+          stdout_is_utf8(stdout_is_utf8) {
+        if (capture_stdout == "never") {
+            this->capture_stdout = CaptureMode::never;
+        } else if (capture_stdout == "onerror") {
+            this->capture_stdout = CaptureMode::onerror;
+        } else if (capture_stdout == "always") {
+            this->capture_stdout = CaptureMode::always;
+        } else {
+            spdlog::error(
+                "'stdout_capture' must be 'never', 'onerror' or 'always'");
+        }
         auto read_log = [this](const char *bytes, std::size_t n) {
+#ifdef WIN32
+            if (!this->stdout_is_utf8) {
+                this->logs += acpToUTF8(bytes, static_cast<int>(n));
+            } else {
+                this->logs.append(bytes, n);
+            }
+#else
             this->logs.append(bytes, n);
+#endif
         };
-        start = wcli.func(name + "_start")
-                    .set([this, read_log] {
-                        if (is_running()) {
-                            spdlog::warn("Command '{}' is already started.",
-                                         this->name);
-                            throw std::runtime_error("already started");
-                        } else {
-                            spdlog::info("Starting command '{}'.", this->name);
-                            this->logs.clear();
+        start =
+            wcli.func(name + "_start")
+                .set([this, read_log] {
+                    if (is_running()) {
+                        spdlog::warn("Command '{}' is already started.",
+                                     this->name);
+                        throw std::runtime_error("already started");
+                    } else {
+                        spdlog::info("Starting command '{}'.", this->name);
+                        this->logs.clear();
+                        if (this->capture_stdout != CaptureMode::never) {
                             p = std::make_shared<TinyProcessLib::Process>(
                                 this->exec, this->workdir, read_log, read_log);
+                        } else {
+                            p = std::make_shared<TinyProcessLib::Process>(
+                                this->exec, this->workdir);
                         }
-                    })
-                    .hidden(true);
+                    }
+                })
+                .hidden(true);
         terminate =
             wcli.func(name + "_terminate")
                 .set([this] {
@@ -44,6 +76,9 @@ struct Command {
     std::string name;
     std::string exec;
     std::string workdir;
+    CaptureMode capture_stdout;
+    bool stdout_is_utf8;
+
     int exit_status = 0;
     std::shared_ptr<TinyProcessLib::Process> p;
     WebCFace::Func start, terminate;


### PR DESCRIPTION
fix #21

* launcherでstdoutとstderrをキャプチャーしないようにするオプション追加
* launcher、sendで入力がutf8かどうか指定するオプション追加(windowsのみ)
	* デフォルトでacpとみなすようにした (ver1.3とは異なる挙動)
