### PR TITLE
launcher status

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -80,7 +80,7 @@ jobs:
           # Produce a binary artifact and place it in the mounted volume
           run: |
             cd /workspace
-            curl -LO https://github.com/na-trium-144/webcface/releases/download/v2.0.1/libwebcface-linux-${{matrix.arch}}.zip
+            curl -LO https://github.com/na-trium-144/webcface/releases/download/v2.4.0/libwebcface-linux-${{matrix.arch}}.zip
             unzip libwebcface-*.zip -d /opt/webcface
             rm libwebcface-*.zip
             meson setup build --buildtype=release --prefix=/opt/webcface -Dversion_suffix= -Dcmake_prefix_path=/opt/webcface
@@ -139,7 +139,7 @@ jobs:
     steps:
     - name: Install webcface
       run: |
-        curl -LO https://github.com/na-trium-144/webcface/releases/download/v2.0.1/libwebcface-macos-universal.zip
+        curl -LO https://github.com/na-trium-144/webcface/releases/download/v2.4.0/libwebcface-macos-universal.zip
         sudo unzip libwebcface-macos-universal.zip -d /opt/webcface
         rm libwebcface-macos-universal.zip
 
@@ -223,7 +223,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: download latest webcface
       run: |
-        Invoke-WebRequest https://github.com/na-trium-144/webcface/releases/download/v2.0.1/libwebcface-windows-${{matrix.arch}}.zip -OutFile webcface.zip
+        Invoke-WebRequest https://github.com/na-trium-144/webcface/releases/download/v2.4.0/libwebcface-windows-${{matrix.arch}}.zip -OutFile webcface.zip
         Expand-Archive -Path webcface.zip -DestinationPath webcface
         Remove-Item webcface.zip
     - name: Add webcface to path

--- a/.github/workflows/cmake-test-linux-gcc.yml
+++ b/.github/workflows/cmake-test-linux-gcc.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: install latest webcface
       run: |
-        curl -LO https://github.com/na-trium-144/webcface/releases/download/v2.0.1/webcface_2.0.1_amd64.deb
+        curl -LO https://github.com/na-trium-144/webcface/releases/download/v2.4.0/webcface_2.4.0_amd64.deb
         sudo apt-get install -y ./*.deb
         rm ./*.deb
 

--- a/.github/workflows/cmake-test-macos-clang.yaml
+++ b/.github/workflows/cmake-test-macos-clang.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Install webcface
       run: |
-        curl -LO https://github.com/na-trium-144/webcface/releases/download/v2.0.1/libwebcface-macos-universal.zip
+        curl -LO https://github.com/na-trium-144/webcface/releases/download/v2.4.0/libwebcface-macos-universal.zip
         sudo unzip libwebcface-macos-universal.zip -d /opt/webcface
         rm libwebcface-macos-universal.zip
 

--- a/.github/workflows/cmake-test-windows-msvc.yml
+++ b/.github/workflows/cmake-test-windows-msvc.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: download latest webcface
       run: |
-        Invoke-WebRequest https://github.com/na-trium-144/webcface/releases/download/v2.0.1/libwebcface-windows-x64.zip -OutFile webcface.zip
+        Invoke-WebRequest https://github.com/na-trium-144/webcface/releases/download/v2.4.0/libwebcface-windows-x64.zip -OutFile webcface.zip
         Expand-Archive -Path webcface.zip -DestinationPath webcface
         Remove-Item webcface.zip
     - name: Add webcface to path

--- a/launcher/command.h
+++ b/launcher/command.h
@@ -60,7 +60,7 @@ struct Process : std::enable_shared_from_this<Process> {
             // 改行で区切り、出力
             auto logs_new_part =
                 std::string_view(cmd->logs).substr(cmd->logs_last_pos);
-            if (logs_new_part.find('\n') != std::string_view::npos) {
+            while (logs_new_part.find('\n') != std::string_view::npos) {
                 auto ln_pos = logs_new_part.find('\n');
                 auto logs_line = logs_new_part.substr(0, ln_pos);
                 cmd->logger->info("{}", logs_line);

--- a/launcher/launcher.cc
+++ b/launcher/launcher.cc
@@ -167,49 +167,8 @@ void launcherLoop(WebCFace::Client &wcli,
                   const std::vector<std::shared_ptr<Command>> &commands) {
     auto v = wcli.view("launcher");
     for (auto c : commands) {
-        v << c->start_p->name << " ";
-        auto start = webcface::button("start", c->start_f);
-        auto stop = webcface::button("stop", c->stop_f);
-        if (c->start_p->is_running()) {
-            // todo: button.disable がほしい
-            start.bgColor(WebCFace::ViewColor::gray);
-            stop.bgColor(WebCFace::ViewColor::orange);
-        } else {
-            start.bgColor(WebCFace::ViewColor::green);
-            stop.bgColor(WebCFace::ViewColor::gray);
-        }
-        v << start;
-        if (c->stop_p.index() != 0) {
-            v << stop;
-        }
-        if (!c->start_p->is_running() && c->start_p->exit_status != 0) {
-            v << webcface::text("(" + std::to_string(c->start_p->exit_status) +
-                                ") ")
-                     .textColor(WebCFace::ViewColor::red);
-        }
-        if (!c->start_p->is_running() &&
-            (c->start_p->exit_status != 0 ||
-             c->start_p->capture_stdout == CaptureMode::always)) {
-            std::string logs = c->start_p->logs;
-            if (!logs.empty()) {
-                v << webcface::button("Clear Logs",
-                                      [c] { c->start_p->logs.clear(); })
-                         .bgColor(webcface::ViewColor::cyan)
-                  << std::endl;
-                for (int i;
-                     (i = logs.find_first_of("\n")) != std::string::npos;) {
-                    v << "　　" << logs.substr(0, i) << std::endl;
-                    logs = logs.substr(i + 1);
-                }
-                if (!logs.empty()) {
-                    v << "　　" << logs << std::endl;
-                }
-            } else {
-                v << std::endl;
-            }
-        } else {
-            v << std::endl;
-        }
+        c->update(wcli);
+        c->updateView(v);
     }
     v.sync();
     wcli.sync();

--- a/launcher/launcher.cc
+++ b/launcher/launcher.cc
@@ -1,4 +1,3 @@
-#include <webcface/webcface.h>
 #include <toml++/toml.hpp>
 #include <string>
 #include <vector>
@@ -117,6 +116,7 @@ std::vector<std::shared_ptr<Command>> parseToml(webcface::Client &wcli,
     auto config_commands = config["command"].as_array();
     for (auto &&config_node : *config_commands) {
         auto start_p = parseTomlProcess(config_node, "");
+        start_p->send_logs = wcli.log(start_p->name);
 
         Command::StopOption stop_p = 2;
         auto t_stop = config_node[toml::path("stop")];
@@ -163,7 +163,7 @@ std::vector<std::shared_ptr<Command>> parseToml(webcface::Client &wcli,
     return commands;
 }
 
-void launcherLoop(WebCFace::Client &wcli,
+void launcherLoop(webcface::Client &wcli,
                   const std::vector<std::shared_ptr<Command>> &commands) {
     auto v = wcli.view("launcher");
     for (auto c : commands) {

--- a/launcher/launcher.h
+++ b/launcher/launcher.h
@@ -1,6 +1,6 @@
 #pragma once
+#include <webcface/client.h>
 #include "command.h"
-#include <webcface/webcface.h>
 #include <toml++/toml.hpp>
 #include <memory>
 #include <vector>
@@ -9,6 +9,6 @@ std::shared_ptr<Process> parseTomlProcess(toml::node &config_node,
                                           const std::string &default_name);
 std::vector<std::shared_ptr<Command>> parseToml(webcface::Client &wcli,
                                                 toml::parse_result &config);
-void launcherLoop(WebCFace::Client &wcli,
+void launcherLoop(webcface::Client &wcli,
                   const std::vector<std::shared_ptr<Command>> &commands);
 std::string tomlSourceInfo(const toml::source_region &src);

--- a/launcher/main.cc
+++ b/launcher/main.cc
@@ -1,4 +1,3 @@
-#include <webcface/webcface.h>
 #include <spdlog/spdlog.h>
 #include <toml++/toml.hpp>
 #include <CLI/CLI.hpp>
@@ -18,7 +17,7 @@ inline void initHandler() {}
 
 
 int main(int argc, char **argv) {
-    CLI::App app{TOOLS_VERSION_DISP("WebCFace Launcher")};
+    CLI::App app{TOOLS_VERSION_DISP("webcface Launcher")};
 
     std::string wcli_host = "", wcli_name = "";
     int wcli_port = 0;
@@ -71,7 +70,7 @@ int main(int argc, char **argv) {
     if (wcli_port == 0) {
         wcli_port = config["init"]["port"].value_or(WEBCFACE_DEFAULT_PORT);
     }
-    WebCFace::Client wcli(wcli_name, wcli_host, wcli_port);
+    webcface::Client wcli(wcli_name, wcli_host, wcli_port);
     std::vector<std::shared_ptr<Command>> commands = parseToml(wcli, config);
 
     initHandler();

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,7 @@ if cxx.get_argument_syntax() == 'msvc'
   )
 endif
 
-webcface_dep = dependency('webcface', version: '>=2.0.0')
+webcface_dep = dependency('webcface', version: '>=2.4.0')
 spdlog_dep = dependency('spdlog')
 tiny_process_library_dep = dependency('tiny-process-library')
 tomlplusplus_dep = dependency('tomlplusplus',


### PR DESCRIPTION
- コマンドの状態をvalueで取得できるようにした&stop関数の待機 (close #41)
- run関数追加
- webcface-sendを使わなくてもlauncherが各コマンドのlogをwebcfaceに直接流す